### PR TITLE
Promote to prod environment

### DIFF
--- a/components/dotnet-basic-vlgquegg/overlays/prod/deployment-patch.yaml
+++ b/components/dotnet-basic-vlgquegg/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-tssc/task-runner:1.7
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/dotnet-basic-vlgquegg:github-1fe977275697dbb4081660d951903cca9da624ca
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/dotnet-basic-vlgquegg:github-1fe977275697dbb4081660d951903cca9da624ca